### PR TITLE
Add configurable prompt templates for processors

### DIFF
--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -33,11 +33,13 @@ export interface RawConfig {
     timeout_seconds?: number;
     check_interval?: number;
     path?: string;
+    prompt_path?: string;
   };
   codex?: {
     timeout_seconds?: number;
     check_interval?: number;
     path?: string;
+    prompt_path?: string;
   };
   processors?: Partial<Record<ProcessorName, boolean>>;
 }
@@ -743,6 +745,14 @@ export class Config {
 
   get codexCheckInterval(): number {
     return this.config.codex?.check_interval ?? DEFAULT_CHECK_INTERVAL;
+  }
+
+  get claudePromptPath(): string | undefined {
+    return this.config.claude.prompt_path;
+  }
+
+  get codexPromptPath(): string | undefined {
+    return this.config.codex?.prompt_path;
   }
 
   get enabledProcessors(): ProcessorName[] {

--- a/src/lib/processors/claude.ts
+++ b/src/lib/processors/claude.ts
@@ -40,7 +40,11 @@ export class ClaudeProcessor {
       branchName
     );
 
-    const commandPrompt = buildIssuePrompt(issueNumber);
+    const commandPrompt = await buildIssuePrompt(
+      issueNumber,
+      PROCESSOR_NAME,
+      this.config.claudePromptPath
+    );
 
     const claudeArgs = [
       this.config.claudePath,

--- a/src/lib/processors/codex.ts
+++ b/src/lib/processors/codex.ts
@@ -50,7 +50,11 @@ export class CodexProcessor {
 			branchName,
 		);
 
-		const commandPrompt = buildIssuePrompt(issueNumber);
+		const commandPrompt = await buildIssuePrompt(
+			issueNumber,
+			PROCESSOR_NAME,
+			this.config.codexPromptPath
+		);
 
 		const codexArgs = [
 			this.config.codexPath,

--- a/src/lib/processors/prompts/claude-default.md
+++ b/src/lib/processors/prompts/claude-default.md
@@ -1,0 +1,47 @@
+# GitHub Issue Workflow for Issue ${issueNumber}
+
+## Role & Goal
+You are an autonomous coding assistant. Your responsibility is to handle GitHub issues end-to-end: setup, analysis, implementation, and PR creation. Always document your actions as GitHub comments. Never ask for approval — just execute the plan.
+
+---
+
+## Setup Phase
+1. Fetch latest branches: `git fetch origin`
+2. Retrieve issue details:
+   - Title → `gh issue view ${issueNumber}`
+
+---
+
+## Analysis Phase
+1. Read full issue content + all comments:
+   - `gh issue view ${issueNumber} --comments`
+2. Create a bullet-point summary of requirements and context.
+3. **If unclear requirements exist:**
+   - Generate clarifying questions.
+   - Post them as a GitHub issue comment.
+   - Stop until answers are provided.
+
+---
+
+## Implementation Phase
+1. Before coding, write or extend tests for the required behavior.
+2. Implement step by step, committing only after tests pass.
+3. After **every change**, run:
+   - `npm run lint`
+   - `npm run test`
+   Continue only if both succeed.
+4. Ensure code consistency with the existing branch.
+5. Commit and push changes.
+6. Create a PR with `gh pr create`.
+
+---
+
+## Communication & Logging
+- After each major phase, post a GitHub comment (setup done, analysis summary, clarifications posted, implementation progress, final PR link).
+- Keep comments structured in bullet-point form for readability.
+
+---
+
+## Completion
+- If clarifications are needed → end with a GitHub issue comment listing questions.
+- If implementation is complete → end with a PR and a comment linking to it.

--- a/src/lib/processors/prompts/codex-default.md
+++ b/src/lib/processors/prompts/codex-default.md
@@ -1,0 +1,47 @@
+# GitHub Issue Workflow for Issue ${issueNumber}
+
+## Role & Goal
+You are an autonomous coding assistant. Your responsibility is to handle GitHub issues end-to-end: setup, analysis, implementation, and PR creation. Always document your actions as GitHub comments. Never ask for approval — just execute the plan.
+
+---
+
+## Setup Phase
+1. Fetch latest branches: `git fetch origin`
+2. Retrieve issue details:
+   - Title → `gh issue view ${issueNumber}`
+
+---
+
+## Analysis Phase
+1. Read full issue content + all comments:
+   - `gh issue view ${issueNumber} --comments`
+2. Create a bullet-point summary of requirements and context.
+3. **If unclear requirements exist:**
+   - Generate clarifying questions.
+   - Post them as a GitHub issue comment.
+   - Stop until answers are provided.
+
+---
+
+## Implementation Phase
+1. Before coding, write or extend tests for the required behavior.
+2. Implement step by step, committing only after tests pass.
+3. After **every change**, run:
+   - `npm run lint`
+   - `npm run test`
+   Continue only if both succeed.
+4. Ensure code consistency with the existing branch.
+5. Commit and push changes.
+6. Create a PR with `gh pr create`.
+
+---
+
+## Communication & Logging
+- After each major phase, post a GitHub comment (setup done, analysis summary, clarifications posted, implementation progress, final PR link).
+- Keep comments structured in bullet-point form for readability.
+
+---
+
+## Completion
+- If clarifications are needed → end with a GitHub issue comment listing questions.
+- If implementation is complete → end with a PR and a comment linking to it.

--- a/tests/prompt.test.ts
+++ b/tests/prompt.test.ts
@@ -1,0 +1,142 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { loadPromptTemplate, buildIssuePrompt } from "../src/lib/processors/prompt";
+
+describe("Prompt loading", () => {
+  let tempDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "prompt-test-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = tempDir;
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe("loadPromptTemplate", () => {
+    test("loads default template from source directory", async () => {
+      const template = await loadPromptTemplate("claude");
+      expect(template).toContain("# GitHub Issue Workflow for Issue ${issueNumber}");
+      expect(template).toContain("## Role & Goal");
+      expect(template).toContain("## Setup Phase");
+      expect(template).toContain("## Analysis Phase");
+      expect(template).toContain("## Implementation Phase");
+    });
+
+    test("loads user override from ~/.imploid/prompts/", async () => {
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+      const customContent = "# Custom Claude Prompt for Issue ${issueNumber}\n\nThis is a custom prompt.";
+      writeFileSync(join(userPromptsDir, "claude-default.md"), customContent, "utf8");
+
+      const template = await loadPromptTemplate("claude");
+      expect(template).toBe(customContent);
+    });
+
+    test("loads custom prompt by path", async () => {
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+      const customContent = "# Experimental Claude Prompt for Issue ${issueNumber}\n\nExperimental prompt.";
+      writeFileSync(join(userPromptsDir, "claude-experimental.md"), customContent, "utf8");
+
+      const template = await loadPromptTemplate("claude", "claude-experimental");
+      expect(template).toBe(customContent);
+    });
+
+    test("throws error when custom prompt not found", async () => {
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+
+      await expect(loadPromptTemplate("claude", "nonexistent")).rejects.toThrow(
+        /Failed to load custom prompt/
+      );
+    });
+
+    test("loads source default when user default not found", async () => {
+      const template = await loadPromptTemplate("claude");
+      expect(template).toContain("# GitHub Issue Workflow for Issue ${issueNumber}");
+    });
+
+    test("user default takes precedence over source default", async () => {
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+      const userContent = "# User Override for Issue ${issueNumber}";
+      writeFileSync(join(userPromptsDir, "claude-default.md"), userContent, "utf8");
+
+      const template = await loadPromptTemplate("claude");
+      expect(template).toBe(userContent);
+      expect(template).not.toContain("## Role & Goal");
+    });
+
+    test("loads codex template", async () => {
+      const template = await loadPromptTemplate("codex");
+      expect(template).toContain("# GitHub Issue Workflow for Issue ${issueNumber}");
+    });
+  });
+
+  describe("buildIssuePrompt", () => {
+    test("substitutes issue number in template", async () => {
+      const prompt = await buildIssuePrompt(42, "claude");
+      expect(prompt).toContain("# GitHub Issue Workflow for Issue 42");
+      expect(prompt).not.toContain("${issueNumber}");
+    });
+
+    test("substitutes multiple occurrences of issue number", async () => {
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+      const customContent =
+        "Issue ${issueNumber} details: gh issue view ${issueNumber}\nProcessing issue ${issueNumber}";
+      writeFileSync(join(userPromptsDir, "claude-default.md"), customContent, "utf8");
+
+      const prompt = await buildIssuePrompt(123, "claude");
+      expect(prompt).toBe("Issue 123 details: gh issue view 123\nProcessing issue 123");
+      expect(prompt).not.toContain("${issueNumber}");
+    });
+
+    test("works with custom prompt path", async () => {
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+      const customContent = "Custom prompt for issue ${issueNumber}";
+      writeFileSync(join(userPromptsDir, "my-custom.md"), customContent, "utf8");
+
+      const prompt = await buildIssuePrompt(999, "claude", "my-custom");
+      expect(prompt).toBe("Custom prompt for issue 999");
+    });
+
+    test("handles issue number conversion to string", async () => {
+      const prompt = await buildIssuePrompt(1, "claude");
+      expect(prompt).toContain("Issue 1");
+    });
+  });
+
+  describe("Error handling", () => {
+    test("throws error when processor has no default template", async () => {
+      await expect(loadPromptTemplate("nonexistent-processor")).rejects.toThrow(
+        /Failed to load default prompt/
+      );
+    });
+
+    test("provides clear error message for missing custom prompt", async () => {
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+
+      try {
+        await loadPromptTemplate("claude", "missing-file");
+        throw new Error("Should have thrown");
+      } catch (error) {
+        expect((error as Error).message).toContain("Failed to load custom prompt");
+        expect((error as Error).message).toContain("missing-file.md");
+      }
+    });
+  });
+});

--- a/tests/promptIntegration.test.ts
+++ b/tests/promptIntegration.test.ts
@@ -1,0 +1,275 @@
+import { describe, test, expect, beforeEach, afterEach, mock } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { ProcessStatus, IssueState } from "../src/lib/models";
+import { createIssueBranchName } from "../src/utils/branch";
+
+type CommandResult = { code: number; stdout: string; stderr: string };
+type SpawnResult = {
+  process: { exited: Promise<number>; kill: () => void };
+  stdout: ReadableStreamDefaultReader<Uint8Array>;
+  stderr: ReadableStreamDefaultReader<Uint8Array>;
+};
+
+let runCommandImpl: (command: string[], options?: { cwd?: string }) => Promise<CommandResult>;
+let spawnProcessImpl: (command: string[], options?: { cwd?: string }) => SpawnResult;
+let capturedPrompts: string[] = [];
+
+const runCommandMock = mock(async (command: string[], options?: { cwd?: string }) => {
+  if (!runCommandImpl) {
+    throw new Error("runCommand implementation not set");
+  }
+  return runCommandImpl(command, options);
+});
+
+const spawnProcessMock = mock((command: string[], options?: { cwd?: string }) => {
+  if (!spawnProcessImpl) {
+    throw new Error("spawnProcess implementation not set");
+  }
+  return spawnProcessImpl(command, options);
+});
+
+mock.module("../src/utils/process", () => ({
+  runCommand: runCommandMock,
+  spawnProcess: spawnProcessMock,
+}));
+
+const encoder = new TextEncoder();
+
+function makeReader(lines: string[]): ReadableStreamDefaultReader<Uint8Array> {
+  const chunks = [...lines.map((line) => encoder.encode(line))];
+  return {
+    read: mock(async () => {
+      if (chunks.length === 0) {
+        return { value: undefined, done: true };
+      }
+      const value = chunks.shift();
+      return { value, done: false };
+    }),
+    releaseLock: () => {},
+    closed: Promise.resolve(undefined),
+    cancel: async () => {},
+  } as ReadableStreamDefaultReader<Uint8Array>;
+}
+
+describe("Prompt Integration Tests", () => {
+  let tempDir: string;
+  let originalHome: string | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "prompt-integration-"));
+    originalHome = process.env.HOME;
+    process.env.HOME = tempDir;
+    capturedPrompts = [];
+    runCommandMock.mock.calls.length = 0;
+    spawnProcessMock.mock.calls.length = 0;
+    runCommandImpl = async () => ({ code: 0, stdout: "", stderr: "" });
+    spawnProcessImpl = () => {
+      throw new Error("spawnProcess implementation not provided for test");
+    };
+  });
+
+  afterEach(() => {
+    if (originalHome !== undefined) {
+      process.env.HOME = originalHome;
+    } else {
+      delete process.env.HOME;
+    }
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const makeConfig = (overrides: Partial<Record<string, unknown>> = {}) => ({
+    claudePath: "claude",
+    claudeTimeout: 120,
+    claudeCheckInterval: 0.05,
+    claudePromptPath: undefined,
+    codexPath: "codex",
+    codexTimeout: 120,
+    codexCheckInterval: 0.05,
+    codexPromptPath: undefined,
+    ...overrides,
+  });
+
+  const makeStateManager = (issueNumber: number, processorName: string) => {
+    const branch = createIssueBranchName(
+      issueNumber,
+      processorName,
+      new Date(Date.UTC(2024, 0, 1, 0, 0, issueNumber % 60))
+    );
+    const state = new IssueState({
+      issue_number: issueNumber,
+      processor_name: processorName,
+      status: ProcessStatus.Running,
+      branch,
+      start_time: new Date().toISOString(),
+    });
+    const store = new Map<number, IssueState>([[issueNumber, state]]);
+    return {
+      branch,
+      getState: mock(() => state),
+      setState: mock(() => {}),
+      saveStates: mock(async () => {}),
+    };
+  };
+
+  const makeRepoManager = () => ({
+    ensureRepoClone: mock(async () => "/fake/repo/path"),
+    prepareDefaultBranch: mock(async () => "main"),
+    checkoutBranch: mock(async () => {}),
+    createBranch: mock(async () => {}),
+    getRepoPath: mock(() => "/fake/repo/path"),
+  });
+
+  describe("Claude processor with custom prompt", () => {
+    test("uses custom prompt when configured", async () => {
+      const { ClaudeProcessor } = await import("../src/lib/processors/claude");
+
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+      const customPrompt = "# Custom Claude Prompt ${issueNumber}\nDo something special!";
+      writeFileSync(join(userPromptsDir, "custom-claude.md"), customPrompt, "utf8");
+
+      const config = makeConfig({ claudePromptPath: "custom-claude" });
+      const stateManager = makeStateManager(42, "claude");
+      const repoManager = makeRepoManager();
+
+      spawnProcessImpl = (command: string[]) => {
+        capturedPrompts.push(command[3]);
+        return {
+          process: { exited: Promise.resolve(0), kill: () => {} },
+          stdout: makeReader(['{"session_id":"test-session"}\n']),
+          stderr: makeReader([]),
+        };
+      };
+
+      const processor = new ClaudeProcessor(config as any, [], repoManager as any);
+      await processor.processIssue(42, 0, stateManager as any);
+
+      expect(capturedPrompts.length).toBe(1);
+      expect(capturedPrompts[0]).toBe("# Custom Claude Prompt 42\nDo something special!");
+    });
+
+    test("uses default prompt when no custom path configured", async () => {
+      const { ClaudeProcessor } = await import("../src/lib/processors/claude");
+
+      const config = makeConfig();
+      const stateManager = makeStateManager(99, "claude");
+      const repoManager = makeRepoManager();
+
+      spawnProcessImpl = (command: string[]) => {
+        capturedPrompts.push(command[3]);
+        return {
+          process: { exited: Promise.resolve(0), kill: () => {} },
+          stdout: makeReader(['{"session_id":"test-session"}\n']),
+          stderr: makeReader([]),
+        };
+      };
+
+      const processor = new ClaudeProcessor(config as any, [], repoManager as any);
+      await processor.processIssue(99, 0, stateManager as any);
+
+      expect(capturedPrompts.length).toBe(1);
+      expect(capturedPrompts[0]).toContain("# GitHub Issue Workflow for Issue 99");
+      expect(capturedPrompts[0]).toContain("## Setup Phase");
+    });
+
+    test("user override takes precedence over source default", async () => {
+      const { ClaudeProcessor } = await import("../src/lib/processors/claude");
+
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+      const userOverride = "# User Override ${issueNumber}\nCustom instructions";
+      writeFileSync(join(userPromptsDir, "claude-default.md"), userOverride, "utf8");
+
+      const config = makeConfig();
+      const stateManager = makeStateManager(123, "claude");
+      const repoManager = makeRepoManager();
+
+      spawnProcessImpl = (command: string[]) => {
+        capturedPrompts.push(command[3]);
+        return {
+          process: { exited: Promise.resolve(0), kill: () => {} },
+          stdout: makeReader(['{"session_id":"test-session"}\n']),
+          stderr: makeReader([]),
+        };
+      };
+
+      const processor = new ClaudeProcessor(config as any, [], repoManager as any);
+      await processor.processIssue(123, 0, stateManager as any);
+
+      expect(capturedPrompts.length).toBe(1);
+      expect(capturedPrompts[0]).toBe("# User Override 123\nCustom instructions");
+    });
+  });
+
+  describe("Codex processor with custom prompt", () => {
+    test("uses custom prompt when configured", async () => {
+      const { CodexProcessor } = await import("../src/lib/processors/codex");
+
+      const userPromptsDir = join(tempDir, ".imploid", "prompts");
+      mkdirSync(userPromptsDir, { recursive: true });
+      const customPrompt = "# Custom Codex Prompt ${issueNumber}\nCodex instructions!";
+      writeFileSync(join(userPromptsDir, "custom-codex.md"), customPrompt, "utf8");
+
+      const config = makeConfig({ codexPromptPath: "custom-codex" });
+      const stateManager = makeStateManager(88, "codex");
+      const repoManager = makeRepoManager();
+
+      spawnProcessImpl = (command: string[]) => {
+        capturedPrompts.push(command[3]);
+        return {
+          process: { exited: Promise.resolve(0), kill: () => {} },
+          stdout: makeReader([]),
+          stderr: makeReader([]),
+        };
+      };
+
+      const processor = new CodexProcessor(config as any, [], repoManager as any);
+      await processor.processIssue(88, 0, stateManager as any);
+
+      expect(capturedPrompts.length).toBe(1);
+      expect(capturedPrompts[0]).toBe("# Custom Codex Prompt 88\nCodex instructions!");
+    });
+
+    test("uses default prompt when no custom path configured", async () => {
+      const { CodexProcessor } = await import("../src/lib/processors/codex");
+
+      const config = makeConfig();
+      const stateManager = makeStateManager(55, "codex");
+      const repoManager = makeRepoManager();
+
+      spawnProcessImpl = (command: string[]) => {
+        capturedPrompts.push(command[3]);
+        return {
+          process: { exited: Promise.resolve(0), kill: () => {} },
+          stdout: makeReader([]),
+          stderr: makeReader([]),
+        };
+      };
+
+      const processor = new CodexProcessor(config as any, [], repoManager as any);
+      await processor.processIssue(55, 0, stateManager as any);
+
+      expect(capturedPrompts.length).toBe(1);
+      expect(capturedPrompts[0]).toContain("# GitHub Issue Workflow for Issue 55");
+      expect(capturedPrompts[0]).toContain("## Implementation Phase");
+    });
+  });
+
+  describe("Error handling", () => {
+    test("fails gracefully when custom prompt file missing", async () => {
+      const { ClaudeProcessor } = await import("../src/lib/processors/claude");
+
+      const config = makeConfig({ claudePromptPath: "nonexistent" });
+      const stateManager = makeStateManager(1, "claude");
+      const repoManager = makeRepoManager();
+
+      const processor = new ClaudeProcessor(config as any, [], repoManager as any);
+
+      await expect(processor.processIssue(1, 0, stateManager as any)).rejects.toThrow(
+        /Failed to load custom prompt/
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Implements per-processor configurable prompt templates using markdown files
- Moves prompts from hardcoded strings to external template files with variable substitution
- Adds `prompt_path` configuration option to processor config blocks
- Implements three-tier template loading precedence for maximum flexibility

## Changes Made

### Core Implementation
- **Refactored `src/lib/processors/prompt.ts`**: Added `loadPromptTemplate()` and updated `buildIssuePrompt()` to support async template loading with customizable paths
- **Created default templates**:
  - `src/lib/processors/prompts/claude-default.md`
  - `src/lib/processors/prompts/codex-default.md`
- **Updated `src/lib/config.ts`**: Added `prompt_path` property to both `claude` and `codex` config schemas, plus getter methods
- **Updated `src/lib/processors/claude.ts`**: Modified to use async prompt loading with config-based path
- **Updated `src/lib/processors/codex.ts`**: Modified to use async prompt loading with config-based path

### Template Loading Precedence
1. **Custom prompt**: `~/.imploid/prompts/{custom-path}.md` (when `prompt_path` is configured)
2. **User override**: `~/.imploid/prompts/{processor}-default.md`
3. **Source default**: `src/lib/processors/prompts/{processor}-default.md`

### Testing
- **`tests/prompt.test.ts`**: 13 unit tests covering template loading, precedence, variable substitution, and error handling
- **`tests/promptIntegration.test.ts`**: 6 integration tests verifying end-to-end processor behavior with custom prompts
- **All tests passing**: 56/56 tests pass

## Test plan
- [x] Basic flow: Default prompts work without configuration
- [x] Custom prompt: Can load custom prompts via `prompt_path` config
- [x] Missing prompt: Clear error when custom prompt not found
- [x] Override precedence: User directory takes precedence over source directory
- [x] Variable substitution: `${issueNumber}` correctly replaced in loaded prompts
- [x] Integration: Both Claude and Codex processors work with custom prompts
- [x] Unit tests: All prompt loading edge cases covered
- [x] All tests pass: 56/56 tests passing

## Documentation
Users can now:
- Create custom prompts: Place markdown files in `~/.imploid/prompts/`
- Configure per processor: Add `"prompt_path": "my-custom-prompt"` to processor config blocks
- Override defaults: Create `claude-default.md` or `codex-default.md` in `~/.imploid/prompts/`
- Use template variables: Reference `${issueNumber}` in templates

Example config:
```json
{
  "claude": {
    "path": "claude",
    "timeout_seconds": 3600,
    "check_interval": 5,
    "prompt_path": "claude-experimental"
  }
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)