### PR TITLE
[Feature] Add ASCII art banner to startup output

### DIFF
--- a/src/lib/startupBanner.ts
+++ b/src/lib/startupBanner.ts
@@ -1,5 +1,14 @@
 import { Config, ProcessorName, SUPPORTED_PROCESSORS } from "./config";
 
+const ASCII_ART = `
+ _                 _       _     _
+(_)_ __ ___  _ __ | | ___ (_) __| |
+| | '_ \` _ \\| '_ \\| |/ _ \\| |/ _\` |
+| | | | | | | |_) | | (_) | | (_| |
+|_|_| |_| |_| .__/|_|\\___/|_|\\__,_|
+            |_|
+`;
+
 export interface StartupBannerOptions {
 	version?: string;
 	description?: string;
@@ -93,6 +102,7 @@ export function buildStartupBanner(
 	const version = options.version ?? "unknown";
 
 	const lines = [
+		ASCII_ART,
 		`imploid v${version} - ${options.description}`,
 		"",
 		formatRepoLine(config),

--- a/tests/startupBanner.test.ts
+++ b/tests/startupBanner.test.ts
@@ -3,7 +3,7 @@ import type { Config, ProcessorName } from "../src/lib/config";
 import { buildStartupBanner } from "../src/lib/startupBanner";
 
 describe("buildStartupBanner", () => {
-    test("summarises configured repos, processors, and notifications", () => {
+    test("includes ASCII art and summarises configured repos, processors, and notifications", () => {
         const originalHome = process.env.HOME;
         process.env.HOME = "/home/test";
 
@@ -35,21 +35,21 @@ describe("buildStartupBanner", () => {
                 processorsOverride: ["claude"],
             });
 
-            expect(lines).toEqual([
-                "imploid v1.2.3 - Coordinates Claude and Codex to work GitHub issues in parallel.",
-                "",
-                "Repos: 3 configured -> hey/mobile-app, hey/marketing-site, +1 more (cache: ~/.imploid/repos)",
-                "Processors: claude active timeout=3600s interval=5s | codex skipped (--processors)",
-                "Concurrency: up to 3 issues at a time",
-                "Notifications: Slack -> C012345 ; Telegram -> off",
-                "",
-            ]);
+            expect(lines[0]).toContain("_");
+            expect(lines[0]).toContain("|");
+            expect(lines[1]).toBe("imploid v1.2.3 - Coordinates Claude and Codex to work GitHub issues in parallel.");
+            expect(lines[2]).toBe("");
+            expect(lines[3]).toBe("Repos: 3 configured -> hey/mobile-app, hey/marketing-site, +1 more (cache: ~/.imploid/repos)");
+            expect(lines[4]).toBe("Processors: claude active timeout=3600s interval=5s | codex skipped (--processors)");
+            expect(lines[5]).toBe("Concurrency: up to 3 issues at a time");
+            expect(lines[6]).toBe("Notifications: Slack -> C012345 ; Telegram -> off");
+            expect(lines[7]).toBe("");
         } finally {
             process.env.HOME = originalHome;
         }
     });
 
-    test("uses fallback text when no repos or processors enabled", () => {
+    test("includes ASCII art and uses fallback text when no repos or processors enabled", () => {
         const config = {
             githubRepos: [],
             baseRepoPath: "",
@@ -68,14 +68,14 @@ describe("buildStartupBanner", () => {
 
         const lines = buildStartupBanner(config);
 
-        expect(lines).toEqual([
-            "imploid vunknown - undefined",
-            "",
-            "Repos: none configured (run imploid --config)",
-            "Processors: claude disabled (config) | codex disabled (config)",
-            "Concurrency: up to 2 issues at a time",
-            "Notifications: Slack -> off ; Telegram -> off",
-            "",
-        ]);
+        expect(lines[0]).toContain("_");
+        expect(lines[0]).toContain("|");
+        expect(lines[1]).toBe("imploid vunknown - undefined");
+        expect(lines[2]).toBe("");
+        expect(lines[3]).toBe("Repos: none configured (run imploid --config)");
+        expect(lines[4]).toBe("Processors: claude disabled (config) | codex disabled (config)");
+        expect(lines[5]).toBe("Concurrency: up to 2 issues at a time");
+        expect(lines[6]).toBe("Notifications: Slack -> off ; Telegram -> off");
+        expect(lines[7]).toBe("");
     });
 });


### PR DESCRIPTION
## Summary
- Added ASCII art banner displaying "imploid" at the top of startup output
- ASCII art appears above the version line as requested
- Automatically respects --quiet flag (suppressed when quiet mode enabled via existing orchestrator logic)
- Updated tests to verify ASCII art inclusion

## Implementation Details
- Added `ASCII_ART` constant to `src/lib/startupBanner.ts:3-10`
- Modified `buildStartupBanner()` function to prepend ASCII art to output array
- Updated both existing tests in `tests/startupBanner.test.ts` to verify ASCII art is present
- No new dependencies added (hardcoded approach as recommended in issue)

## Test Plan
✅ Unit tests passing (2/2 tests in startupBanner.test.ts)
✅ Manual testing complete:
  - Basic flow: Verified ASCII art appears above version line
  - Quiet mode: Confirmed --quiet flag properly suppresses banner (via existing orchestrator.ts:320 logic)
  - Version display: Verified version and description info still appear correctly after ASCII art
  - Integration: Verified ASCII art works correctly with normal startup

## Files Modified
- `src/lib/startupBanner.ts` - Added ASCII_ART constant and prepended to banner output
- `tests/startupBanner.test.ts` - Updated tests to verify ASCII art inclusion

Resolves #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)