### PR TITLE
Add ASCII art banner to startup output

### DIFF
--- a/src/lib/startupBanner.ts
+++ b/src/lib/startupBanner.ts
@@ -1,5 +1,14 @@
 import { Config, ProcessorName, SUPPORTED_PROCESSORS } from "./config";
 
+const ASCII_BANNER = [
+	"  _                 _       _     _ ",
+	" (_)_ __ ___  _ __ | | ___ (_) __| |",
+	" | | '_ ` _ \\| '_ \\| |/ _ \\| |/ _` |",
+	" | | | | | | | |_) | | (_) | | (_| |",
+	" |_|_| |_| |_| .__/|_|\\___/|_|\\__,_|",
+	"             |_|                    ",
+] as const;
+
 export interface StartupBannerOptions {
 	version?: string;
 	description?: string;
@@ -93,6 +102,8 @@ export function buildStartupBanner(
 	const version = options.version ?? "unknown";
 
 	const lines = [
+		...ASCII_BANNER,
+		"",
 		`imploid v${version} - ${options.description}`,
 		"",
 		formatRepoLine(config),

--- a/tests/startupBanner.test.ts
+++ b/tests/startupBanner.test.ts
@@ -36,6 +36,13 @@ describe("buildStartupBanner", () => {
             });
 
             expect(lines).toEqual([
+                "  _                 _       _     _ ",
+                " (_)_ __ ___  _ __ | | ___ (_) __| |",
+                " | | '_ ` _ \\| '_ \\| |/ _ \\| |/ _` |",
+                " | | | | | | | |_) | | (_) | | (_| |",
+                " |_|_| |_| |_| .__/|_|\\___/|_|\\__,_|",
+                "             |_|                    ",
+                "",
                 "imploid v1.2.3 - Coordinates Claude and Codex to work GitHub issues in parallel.",
                 "",
                 "Repos: 3 configured -> hey/mobile-app, hey/marketing-site, +1 more (cache: ~/.imploid/repos)",
@@ -69,6 +76,13 @@ describe("buildStartupBanner", () => {
         const lines = buildStartupBanner(config);
 
         expect(lines).toEqual([
+            "  _                 _       _     _ ",
+            " (_)_ __ ___  _ __ | | ___ (_) __| |",
+            " | | '_ ` _ \\| '_ \\| |/ _ \\| |/ _` |",
+            " | | | | | | | |_) | | (_) | | (_| |",
+            " |_|_| |_| |_| .__/|_|\\___/|_|\\__,_|",
+            "             |_|                    ",
+            "",
             "imploid vunknown - undefined",
             "",
             "Repos: none configured (run imploid --config)",


### PR DESCRIPTION
## Summary
- add a static figlet-style ASCII banner for "imploid"
- prepend the banner to the startup output alongside existing metadata
- update startup banner tests to cover the new banner lines

## Testing
- npm run lint *(fails: script not defined in package.json)*
- npm run test *(fails: missing optional dependencies such as inquirer during config-related suites)*