### PR TITLE
Create PRs as drafts by default

### DIFF
--- a/src/lib/processors/prompts/claude-default.md
+++ b/src/lib/processors/prompts/claude-default.md
@@ -32,7 +32,7 @@ You are an autonomous coding assistant. Your responsibility is to handle GitHub 
    Continue only if both succeed.
 4. Ensure code consistency with the existing branch.
 5. Commit and push changes.
-6. Create a PR with `gh pr create`.
+6. Create a draft PR with `gh pr create --draft`.
 
 ---
 

--- a/src/lib/processors/prompts/codex-default.md
+++ b/src/lib/processors/prompts/codex-default.md
@@ -31,7 +31,7 @@ You are an autonomous coding assistant. Your responsibility is to handle GitHub 
    Proceed only if both succeed.  
 4. Ensure code consistency with the existing branch.  
 5. Commit and push changes.  
-6. Create a PR with `gh pr create`.  
+6. Create a draft PR with `gh pr create --draft`.  
 
 ---
 


### PR DESCRIPTION
## Summary
- Update Claude and Codex processor prompts to create draft PRs instead of ready-for-review PRs
- Agents now use `gh pr create --draft` by default

## Test plan
- [ ] Run imploid with an agent-ready issue
- [ ] Verify the created PR is in draft state

🤖 Generated with [Claude Code](https://claude.com/claude-code)